### PR TITLE
Exchange analysis tab video because of Sars... typo

### DIFF
--- a/omero_gallery/templates/webgallery/categories/index.html
+++ b/omero_gallery/templates/webgallery/categories/index.html
@@ -421,7 +421,7 @@ mark {
           <!-- TODO: load from config file -->
           <div class="row horizontal">
             <div class="small-6 medium-6 large-6 columns" style="position: relative;">
-              <iframe id="youtube" width="100%" height="100%" src="https://www.youtube.com/embed/qa7b7rdfvzo"
+              <iframe id="youtube" width="100%" height="100%" src="https://www.youtube.com/embed/2qeJbudXnp4"
                 title="YouTube video player" frameborder="0"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
               </iframe>


### PR DESCRIPTION
@will-moore Fixes the last-added video teaser on the second tab, Sars... typo.